### PR TITLE
Fix some issues when running code on Windows

### DIFF
--- a/dephell_pythons/_finder.py
+++ b/dephell_pythons/_finder.py
@@ -69,14 +69,9 @@ class Finder:
     def pythons(self) -> List[Python]:
         pythons = []
         for path in self.get_pythons():
-            try:
-                version = Version(self.get_version(path))
-            except LookupError as err:
-                continue
-
             pythons.append(Python(
                 path=path,
-                version=version,
+                version=Version(self.get_version(path)),
                 implementation=self.get_implementation(path) or 'python',
                 shim=self.in_shims(path=path),
             ))
@@ -96,10 +91,7 @@ class Finder:
         # get version from CLI for cpython
         if path.name.startswith('python'):
             # this works much faster, so let's do it if possible
-            try:
-                result = subprocess.run([str(path), '--version'], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-            except OSError as err:
-                raise LookupError(str(err)) from err
+            result = subprocess.run([str(path), '--version'], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
             if result.returncode != 0:
                 raise LookupError(result.stderr.decode())
             # cpython 2 writes version into stderr
@@ -108,10 +100,7 @@ class Finder:
 
         # get version from interpreter for other implementations (like pypy)
         command = r'print(__import__("sys").version)'
-        try:
-            result = subprocess.run([str(path), '-c', command], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-        except OSError as err:
-            raise LookupError(str(err)) from err
+        result = subprocess.run([str(path), '-c', command], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         if result.returncode != 0:
             raise LookupError(result.stderr.decode())
         return result.stdout.decode().split()[0].rstrip('+')

--- a/dephell_pythons/_shell_utils.py
+++ b/dephell_pythons/_shell_utils.py
@@ -13,7 +13,7 @@ def is_executable(path: Path) -> bool:
     try:
         if not path.is_file():
             return False
-    except PermissionError:
+    except (PermissionError, OSError):
         return False
     if not os.access(str(path), os.X_OK):
         return False
@@ -29,7 +29,7 @@ def is_dir(path: Path) -> bool:
     try:
         if not path.is_dir():
             return False
-    except PermissionError:
+    except (PermissionError, OSError):
         return False
     if not os.access(str(path), os.R_OK):
         return False

--- a/dephell_pythons/_shell_utils.py
+++ b/dephell_pythons/_shell_utils.py
@@ -13,7 +13,7 @@ def is_executable(path: Path) -> bool:
     try:
         if not path.is_file():
             return False
-    except (PermissionError, OSError):
+    except OSError:
         return False
     if not os.access(str(path), os.X_OK):
         return False
@@ -29,7 +29,7 @@ def is_dir(path: Path) -> bool:
     try:
         if not path.is_dir():
             return False
-    except (PermissionError, OSError):
+    except OSError:
         return False
     if not os.access(str(path), os.R_OK):
         return False

--- a/dephell_pythons/_windows.py
+++ b/dephell_pythons/_windows.py
@@ -17,12 +17,13 @@ class WindowsFinder:
 
         pythons = []
         for env in findall():
-            path = getattr(env.info._d['InstallPath'], 'executable_path', None)
+            d = env.info._d
+            path = getattr(d.get('InstallPath'), 'executable_path', None)
             if path is None:
-                path = getattr(env.info._d['InstallPath'], '', None)
+                path = getattr(d.get('InstallPath'), '', None)
                 if path is None:
                     continue
-            version = str(env.info._d['Version'])
+            version = str(d['Version'])
             # conda returns it's own version
             if version[0] not in '23':
                 continue


### PR DESCRIPTION
The PR fixes some issues which occur when running code on windows:
- `OSError: [WinError 1920]`: the file cannot be accessed by the system
- `OSError: [WinError 193]`: the file is not a valid Win32 application
- Using `WindowsFinder` and `findall` (Sometimes the windows registry may contain the info about Python installations without `InstallPath`)
